### PR TITLE
Added function to find available external dems and changed the default snap dems

### DIFF
--- a/workflows/utils/s1am/raw2ard.py
+++ b/workflows/utils/s1am/raw2ard.py
@@ -248,10 +248,10 @@ class Raw2Ard:
             snap_gpt = os.getenv("GPT_PATH", '/opt/snap/bin/gpt')  # set env var for testing or use default
             int_graph_1 = 'workflows/utils/cs_s1_pt1_bnr_Orb_Cal_ML.xml'
 
-            # find out which region we're looking at, for discovering external dems (if any)
-            avaliable_regions = ['fiji', 'vanuatu', 'solomon']  # TO DO - MAKE THIS AN ENV VAR (see also prep_utils.download_external_dems())
+            # find which regions we have external dems for
+            available_regions = get_available_regions(region, s3_bucket)
 
-            if region.lower() in avaliable_regions:
+            if region.lower() in available_regions:
                 if region.lower() == 'fiji':
                     # find out if the image is in east or west and use that dem
                     logging.info('THE META AOI - TO FIND LONGITUDE')

--- a/workflows/utils/without_external_dems/cs_s1_pt2A_TF.xml
+++ b/workflows/utils/without_external_dems/cs_s1_pt2A_TF.xml
@@ -14,7 +14,7 @@
     </sources>
     <parameters class="com.bc.ceres.binding.dom.XppDomElement">
       <sourceBands/>
-      <demName>SRTM 3Sec</demName>
+      <demName>SRTM 1Sec HGT</demName>
       <demResamplingMethod>BILINEAR_INTERPOLATION</demResamplingMethod>
       <externalDEMFile/>
       <nodataValueAtSea>false</nodataValueAtSea>

--- a/workflows/utils/without_external_dems/cs_s1_pt3A_TC_db.xml
+++ b/workflows/utils/without_external_dems/cs_s1_pt3A_TC_db.xml
@@ -14,7 +14,7 @@
     </sources>
     <parameters class="com.bc.ceres.binding.dom.XppDomElement">
       <sourceBands>$source_bands</sourceBands>
-      <demName>SRTM 3Sec</demName>
+      <demName>SRTM 1Sec HGT</demName>
       <externalDEMFile/>
       <externalDEMNoDataValue>-9999.0</externalDEMNoDataValue>
       <externalDEMApplyEGM>false</externalDEMApplyEGM>

--- a/workflows/utils/without_external_dems/cs_s1_pt4A_Sm_Bm_TC_lsm.xml
+++ b/workflows/utils/without_external_dems/cs_s1_pt4A_Sm_Bm_TC_lsm.xml
@@ -14,7 +14,7 @@
     </sources>
     <parameters class="com.bc.ceres.binding.dom.XppDomElement">
       <sourceBands/>
-      <demName>SRTM 3Sec</demName>
+      <demName>SRTM 1Sec HGT</demName>
       <demResamplingMethod>BICUBIC_INTERPOLATION</demResamplingMethod>
       <externalDEMFile/>
       <externalDEMNoDataValue>-9999.0</externalDEMNoDataValue>
@@ -48,7 +48,7 @@
     </sources>
     <parameters class="com.bc.ceres.binding.dom.XppDomElement">
       <sourceBands/>
-      <demName>SRTM 3Sec</demName>
+      <demName>SRTM 1Sec HGT</demName>
       <externalDEMFile/>
       <externalDEMNoDataValue>-9999.0</externalDEMNoDataValue>
       <externalDEMApplyEGM>false</externalDEMApplyEGM>


### PR DESCRIPTION
Created the get_available_regions() function in prep_utils.py which is used to find the available external dems by region. Used in prep_utils and raw2ard.py

Changed the default snap dems from SRTM 3Sec to SRTM 1Sec HGT, inside the xml files in the without_external_dems directory