### PR TITLE
fix: change cog_dir to scale_dir

### DIFF
--- a/workflows/utils/prepLS.py
+++ b/workflows/utils/prepLS.py
@@ -235,8 +235,8 @@ def scale_landsat_l2(untar_dir, scale_dir, new_dtype='float32'):
 
     Note: Check on assigning new data type of float32 and converting to COG multiple times.
     """
-    # All the files in the directory (includes QA bands and xml file)
-    filenames = glob.glob(f"{untar_dir}/*")
+    # All files in the directory (includes QA bands and xml file) but avoids any files in subdirectories
+    filenames = [f for f in glob.glob(f"{untar_dir}/*") if os.path.isfile(f)]
 
     # Variable scale factors for supplementary ST bands
     scale_factor_map = {
@@ -655,7 +655,10 @@ if __name__ == '__main__':
     #prepareLS("https://edclpdsftp.cr.usgs.gov/orders/espa-sabine.a.nix@gmail.com-09222023-055747-096/LE070860662006042702T1-SC20230922143843.tar.gz")
 
     # # No projection, L5/L2 
-    prepareLS("https://edclpdsftp.cr.usgs.gov/orders/espa-sabine.a.nix@gmail.com-10022023-081357-181/LT051690712011111702T1-SC20231002131439.tar.gz")
+    #prepareLS("https://edclpdsftp.cr.usgs.gov/orders/espa-sabine.a.nix@gmail.com-10022023-081357-181/LT051690712011111702T1-SC20231002131439.tar.gz")
 
     # # No projection, L5/L2
     #prepareLS("https://edclpdsftp.cr.usgs.gov/orders/espa-sabine.a.nix@gmail.com-10022023-081357-181/LT050020722011111502T1-SC20231002131438.tar.gz")
+
+    # Test w/ Ivica's Order
+    prepareLS("https://edclpdsftp.cr.usgs.gov/orders/espa-ivica.matic@spatialdays.com-10062023-060411-208/LC080760712020091002T2-SC20231006110509.tar.gz")

--- a/workflows/utils/prepS2.py
+++ b/workflows/utils/prepS2.py
@@ -588,7 +588,7 @@ def prepareS2(title, s3_bucket='public-eo-data', s3_dir='common_sensing/sentinel
         # PARSE METADATA TO TEMP COG DIRECTORY**
         try:
             root.info(f"{in_scene} {scene_name} Copying original METADATA")
-            copy_s2_metadata(down_dir, cog_dir, scene_name)
+            copy_s2_metadata(down_dir, scale_dir, scene_name)
             root.info(f"{in_scene} {scene_name} COPIED original METADATA")
         except:
             root.exception(f"{in_scene} {scene_name} MTD not coppied")
@@ -596,17 +596,16 @@ def prepareS2(title, s3_bucket='public-eo-data', s3_dir='common_sensing/sentinel
         # GENERATE YAML WITHIN TEMP COG DIRECTORY**
         try:
             root.info(f"{in_scene} {scene_name} Creating dataset YAML")
-            create_yaml(cog_dir, yaml_prep_s2(cog_dir))
+            create_yaml(scale_dir, yaml_prep_s2(scale_dir))
             root.info(f"{in_scene} {scene_name} Created original METADATA")
         except Exception as e:
             root.exception(f"{in_scene} {scene_name} Dataset YAML not created")
             raise Exception('YAML creation error', e)
 
             # MOVE COG DIRECTORY TO OUTPUT DIRECTORY
-
         try:
             root.info(f"{in_scene} {scene_name} Uploading to S3 Bucket")
-            s3_upload_cogs(glob.glob(cog_dir + '*'), s3_bucket, s3_dir)
+            s3_upload_cogs(glob.glob(scale_dir + '*'), s3_bucket, s3_dir)
             root.info(f"{in_scene} {scene_name} Uploaded to S3 Bucket")
         except Exception as e:
             root.exception(f"{in_scene} {scene_name} Upload to S3 Failed")


### PR DESCRIPTION
Changed cog_dir to scale_dir in the sentinel-2 ard (and confirmed that the cogs still have the right CRS and metadata)